### PR TITLE
feat: change the default install_path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cat aqua-installer | bash
+    - run: echo "${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin" >> $GITHUB_PATH
     - run: command -v aqua
     - run: aqua -v
   set-version:
@@ -19,6 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cat aqua-installer | bash -s -- -v v0.1.0-9
+    - run: echo "${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin" >> $GITHUB_PATH
     - run: command -v aqua
     - run: aqua -v
   set-absolute-path:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v0.6.0/aq
 You can pass the following parameters.
 
 * `-v [aqua version]`: aqua version
-* `-i [aqua install path]`: aqua's install path (default: `/usr/local/bin/aqua`)
+* `-i [aqua install path]`: aqua's install path (default: `${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua`)
 
 e.g.
 
@@ -64,7 +64,7 @@ aqua_version | Installed aqua version
 
 name | default | description
 --- | --- | ---
-install_path | /usr/local/bin/aqua | aqua's install path
+install_path | ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua | aqua's install path
 enable_aqua_install | `"true"` | if this is `"false"`, executing `aqua i` and updating `GITHUB_PATH` are skipped
 aqua_opts | `-l` | `aqua i`'s option. If you want to specify global options, please use environment variables
 working_directory | `""` | working directory

--- a/action.sh
+++ b/action.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+if [ -n "${AQUA_INSTALL_PATH:-}" ]; then
+	"$GITHUB_ACTION_PATH/aqua-installer" -v "${AQUA_VERSION}" -i "${AQUA_INSTALL_PATH}"
+	# shellcheck disable=SC2086
+	"${AQUA_INSTALL_PATH}" i $AQUA_OPTS
+	exit 0
+fi
+
+"$GITHUB_ACTION_PATH/aqua-installer" -v "${AQUA_VERSION}"
+# shellcheck disable=SC2086
+aqua i $AQUA_OPTS

--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,6 @@ inputs:
   install_path:
     description: aqua's install path
     required: false
-    default: /usr/local/bin/aqua
   enable_aqua_install:
     required: false
     default: "true"
@@ -25,14 +24,16 @@ runs:
         exit 1
       shell: bash
       if: inputs.aqua_version == ''
-    - run: ${{ github.action_path }}/aqua-installer -v "${{ inputs.aqua_version }}" -i "${{ inputs.install_path }}"
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-    - run: ${{ inputs.install_path }} i ${{ inputs.aqua_opts }}
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-      if: inputs.enable_aqua_install == 'true'
+
     - run: echo "${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin" >> $GITHUB_PATH
       shell: bash
       working-directory: ${{ inputs.working_directory }}
       if: inputs.enable_aqua_install == 'true'
+
+    - run: bash "${{github.action_path}}/action.sh"
+      working-directory: ${{ inputs.working_directory }}
+      shell: bash
+      env:
+        AQUA_INSTALL_PATH: ${{ inputs.install_path }}
+        AQUA_VERSION: ${{ inputs.aqua_version }}
+        AQUA_OPTS: ${{ inputs.aqua_opts }}

--- a/aqua-installer
+++ b/aqua-installer
@@ -9,7 +9,7 @@ usage_exit() {
   exit 1
 }
 
-install_path=/usr/local/bin/aqua
+install_path=${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua
 
 while getopts i:v: OPT
 do


### PR DESCRIPTION
## Motivation

By default, the root privilege is required to install aqua at `/usr/local/bin/aqua`.
It isn't good. So we want to change the default install path.

## ⚠️ Breaking Changes

Change the default install path from `/usr/local/bin/aqua` to `${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua`

The root privilege isn't needed.

GitHub Actions `aqua-installer` adds `${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin` to the environment variable `PATH`.

The install script `aqua-installer` doesn't update the environment variable `PATH`,
so you have to add `${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin` to the environment variable `PATH` before executing aqua.