### PR TITLE
feat: add installer written in Go

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,79 @@
+---
+name: integration-test
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3.2.1
+      with:
+        go-version: '1.18.4'
+        cache: true
+
+    - run: go run main.go -help
+    - run: go run main.go -version
+
+    - run: go run main.go
+    - run: $HOME/.local/share/aquaproj-aqua/bin/aqua -v
+
+    - name: Test overwrite
+      run: go run main.go -aqua-version v1.17.0
+    - run: $HOME/.local/share/aquaproj-aqua/bin/aqua -v
+
+    - name: Test latest and -o
+      run: go run main.go -aqua-version latest -o $HOME/bin/aqua
+    - run: $HOME/bin/aqua -v
+
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3.2.1
+      with:
+        go-version: '1.18.4'
+        cache: true
+
+    - run: go run main.go -help
+    - run: go run main.go -version
+
+    - run: go run main.go
+    - run: C:\\Users\\runneradmin\\AppData\\Local\\aquaproj-aqua\\bin\\aqua.exe -v
+
+    - name: Test overwrite
+      run: go run main.go -aqua-version v1.17.0
+    - run: C:\\Users\\runneradmin\\AppData\\Local\\aquaproj-aqua\\bin\\aqua.exe -v
+
+    - name: Test latest and -o
+      run: go run main.go -aqua-version latest -o C:\\Users\\runneradmin\\bin\\aqua.exe
+    - run: C:\\Users\\runneradmin\\bin\\aqua.exe -v
+
+  build-windows-pwsh:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3.2.1
+      with:
+        go-version: '1.18.4'
+        cache: true
+
+    - run: go run main.go -help
+    - run: go run main.go -version
+
+    - run: go run main.go
+    - run: C:\\Users\\runneradmin\\AppData\\Local\\aquaproj-aqua\\bin\\aqua.exe -v
+
+    - name: Test overwrite
+      run: go run main.go -aqua-version v1.17.0
+    - run: C:\\Users\\runneradmin\\AppData\\Local\\aquaproj-aqua\\bin\\aqua.exe -v
+
+    - name: Test latest and -o
+      run: go run main.go -aqua-version latest -o C:\\Users\\runneradmin\\bin\\aqua.exe
+    - run: C:\\Users\\runneradmin\\bin\\aqua.exe -v

--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ $ curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v1.0.0/aq
 
 If the version isn't specified, the latest version would be installed.
 
+## Go
+
+```console
+$ go run github.com/aquaproj/aqua-installer@latest -help
+aqua-installer - Install aqua
+
+https://github.com/aquaproj/aqua-installer
+
+Usage:
+	$ aqua-installer [--aqua-version latest] [-o <install path>] [-os <OS>] [-arch <ARCH>]
+
+Options:
+	--help          show this help message
+	--version       show aqua-installer version
+	--aqua-version  aqua version. The default value is "latest"
+	-o              File Path where aqua is installed. The default value is ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin
+	-os             OS (e.g. linux, darwin, windows). By default, Go's runtime.GOOS. You can change by the environment variable AQUA_GOOS
+	-arch           CPU Architecture (amd64 or arm64). By default, Go's runtime.GOARCH. You can change by the environment variable AQUA_GOARCH
+```
+
+e.g.
+
+```console
+$ go run github.com/aquaproj/aqua-installer@latest
+```
+
 ## GitHub Actions
 
 e.g.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquaproj/aqua-installer
+
+go 1.18
+
+require github.com/adrg/xdg v0.4.0
+
+require golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+
+	"github.com/aquaproj/aqua-installer/pkg/api"
+)
+
+var (
+	version = ""
+	commit  = "" //nolint:gochecknoglobals
+	date    = "" //nolint:gochecknoglobals
+)
+
+func main() {
+	if err := api.Run(&api.LDFlags{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type LDFlags struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
+type Param struct {
+	AquaVersion string
+	Dest        string
+	OS          string
+	Arch        string
+	Help        bool
+	Version     bool
+}
+
+const helpMessage = `aqua-installer - Install aqua
+
+https://github.com/aquaproj/aqua-installer
+
+Usage:
+	$ aqua-installer [--aqua-version latest] [-o <install path>] [-os <OS>] [-arch <ARCH>]
+
+Options:
+	--help          show this help message
+	--version       show aqua-installer version
+	--aqua-version  aqua version. The default value is "latest"
+	-o              File Path where aqua is installed. The default value is ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin
+	-os             OS (e.g. linux, darwin, windows). By default, Go's runtime.GOOS. You can change by the environment variable AQUA_GOOS
+	-arch           CPU Architecture (amd64 or arm64). By default, Go's runtime.GOARCH. You can change by the environment variable AQUA_GOARCH
+`
+
+const (
+	dirPermission  os.FileMode = 0o755
+	filePermission os.FileMode = 0o755
+)
+
+func Run(ldflags *LDFlags) error {
+	ctx := context.Background()
+
+	param := &Param{}
+	flag.StringVar(&param.AquaVersion, "aqua-version", "latest", "aqua version")
+	flag.StringVar(&param.Dest, "o", "", "File Path where aqua is installed. The default value is ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin")
+	flag.StringVar(&param.OS, "os", "", "OS (e.g. linux, darwin, windows). By default, Go's runtime.GOOS. You can change by the environment variable AQUA_GOOS")
+	flag.StringVar(&param.Arch, "arch", "", "CPU Architecture (amd64 or arm64). By default, Go's runtime.GOARCH. You can change by the environment variable AQUA_GOARCH")
+	flag.BoolVar(&param.Help, "help", false, "show this help")
+	flag.BoolVar(&param.Version, "version", false, "show aqua-docker version")
+	flag.Parse()
+
+	if param.Help {
+		fmt.Fprint(os.Stderr, helpMessage)
+		return nil
+	}
+
+	if param.Version {
+		fmt.Fprintf(os.Stderr, "%s (%s)", ldflags.Version, ldflags.Commit)
+		return nil
+	}
+
+	if param.OS == "" {
+		param.OS = os.Getenv("AQUA_GOOS")
+		if param.OS == "" {
+			param.OS = runtime.GOOS
+		}
+	}
+	if param.Arch == "" {
+		param.Arch = os.Getenv("AQUA_GOARCH")
+		if param.Arch == "" {
+			param.Arch = runtime.GOARCH
+		}
+	}
+
+	if param.Dest == "" {
+		param.Dest = filepath.Join(getRootDir(), "bin", "aqua")
+		if param.OS == "windows" {
+			param.Dest += ".exe"
+		}
+	}
+
+	log.Printf("[INFO] Installing aqua %s to %s", param.AquaVersion, param.Dest)
+	if err := installAqua(ctx, param); err != nil {
+		return fmt.Errorf("install aqua: %w", err)
+	}
+	return nil
+}
+
+func installAqua(ctx context.Context, param *Param) error {
+	if err := os.MkdirAll(filepath.Dir(param.Dest), dirPermission); err != nil {
+		return fmt.Errorf("create a directory where aqua is installed: %w", err)
+	}
+	u := ""
+	if param.AquaVersion == "latest" {
+		u = fmt.Sprintf("https://github.com/aquaproj/aqua/releases/latest/download/aqua_%s_%s.tar.gz", param.OS, param.Arch)
+	} else {
+		u = fmt.Sprintf("https://github.com/aquaproj/aqua/releases/download/%s/aqua_%s_%s.tar.gz", param.AquaVersion, param.OS, param.Arch)
+	}
+	log.Printf("Downloading %s", u)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return fmt.Errorf("create a HTTP request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send a HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read a response body: %w", err)
+		}
+		return fmt.Errorf("download aqua but status code >= 400: status_code=%d, response_body=%s", resp.StatusCode, string(b))
+	}
+	f, err := os.OpenFile(param.Dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePermission)
+	if err != nil {
+		return fmt.Errorf("create a file %s: %w", param.Dest, err)
+	}
+	// f, err := os.Create(param.Dest)
+	// if err != nil {
+	// 	return fmt.Errorf("create a file %s: %w", param.Dest, err)
+	// }
+	defer f.Close()
+	// if err := os.Chmod(param.Dest, filePermission); err != nil {
+	// 	return fmt.Errorf("change a file permission %s: %w", param.Dest, err)
+	// }
+	if err := unarchive(f, resp.Body, param.OS == "windows"); err != nil {
+		return fmt.Errorf("downloand and unarchive aqua: %w", err)
+	}
+	return nil
+}

--- a/pkg/api/root_dir.go
+++ b/pkg/api/root_dir.go
@@ -1,0 +1,20 @@
+//go:build !windows
+// +build !windows
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func getRootDir() string {
+	if rootDir := os.Getenv("AQUA_ROOT_DIR"); rootDir != "" {
+		return rootDir
+	}
+	xdgDataHome := os.Getenv("XDG_DATA_HOME")
+	if xdgDataHome == "" {
+		xdgDataHome = filepath.Join(os.Getenv("HOME"), ".local", "share")
+	}
+	return filepath.Join(xdgDataHome, "aquaproj-aqua")
+}

--- a/pkg/api/root_dir_windows.go
+++ b/pkg/api/root_dir_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+// +build windows
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+)
+
+func getRootDir() string {
+	if rootDir := os.Getenv("AQUA_ROOT_DIR"); rootDir != "" {
+		return rootDir
+	}
+	xdgDataHome := xdg.DataHome
+	if xdgDataHome == "" {
+		xdgDataHome = filepath.Join(os.Getenv("HOME"), ".local", "share")
+	}
+	return filepath.Join(xdg.DataHome, "aquaproj-aqua")
+}

--- a/pkg/api/unarchive.go
+++ b/pkg/api/unarchive.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const maxFileSize = 1073741824 // 1GB
+
+var (
+	errAquaNotFoundInTarball = errors.New("aqua isn't found in tarball")
+	errTooBigTarBall         = errors.New("tarball is too big")
+)
+
+func unarchive(dest io.Writer, src io.Reader, isWindows bool) error {
+	zr, err := gzip.NewReader(src)
+	if err != nil {
+		return fmt.Errorf("create a gzip reader: %w", err)
+	}
+	defer zr.Close()
+	tr := tar.NewReader(zr)
+	exeName := "aqua"
+	if isWindows {
+		exeName += ".exe"
+	}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return errAquaNotFoundInTarball
+		}
+		if err != nil {
+			return fmt.Errorf("read a tarball: %w", err)
+		}
+		if hdr.Name != exeName {
+			continue
+		}
+		writeCount, err := io.CopyN(dest, tr, maxFileSize)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, io.EOF) {
+			return fmt.Errorf("copy aqua: %w", err)
+		}
+		if writeCount >= maxFileSize {
+			return errTooBigTarBall
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Add an install script written in Go.

```console
$ go run github.com/aquaproj/aqua-installer@latest -help
aqua-installer - Install aqua

https://github.com/aquaproj/aqua-installer

Usage:
	$ aqua-installer [--aqua-version latest] [-o <install path>] [-os <OS>] [-arch <ARCH>]

Options:
	--help          show this help message
	--version       show aqua-installer version
	--aqua-version  aqua version. The default value is "latest"
	-o              File Path where aqua is installed. The default value is ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin
	-os             OS (e.g. linux, darwin, windows). By default, Go's runtime.GOOS. You can change by the environment variable AQUA_GOOS
	-arch           CPU Architecture (amd64 or arm64). By default, Go's runtime.GOARCH. You can change by the environment variable AQUA_GOARCH
```

e.g.

```console
$ go run github.com/aquaproj/aqua-installer@latest
```