### PR TITLE
ci: test in macOS

### DIFF
--- a/.github/workflows/test-actions-windows-bash.yaml
+++ b/.github/workflows/test-actions-windows-bash.yaml
@@ -1,9 +1,6 @@
 ---
 name: test-actions-windows-bash
 on:
-  push:
-    branches: [main]
-    tags: [v*]
   pull_request:
     branches: [main]
 permissions:

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -1,0 +1,20 @@
+---
+name: test-actions-macos
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  default:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - uses: ./
+        with:
+          aqua_version: v1.26.1
+          working_directory: tests
+      - run: command -v aqua
+      - run: aqua -v
+      - run: github-comment -v
+        working-directory: tests

--- a/aqua-installer
+++ b/aqua-installer
@@ -60,13 +60,22 @@ echo "===> Downloading $URL ..." >&2
 curl --fail -L "$URL" -o "$tempdir/$filename"
 
 cd "$tempdir"
-echo "===> Verifying checksum of aqua $bootstrap_version ..." >&2
-echo "115d9122cc8ee91972ee07d8d706f246f53e7b9728574d7089683195d6194dee  aqua_darwin_arm64.tar.gz
+
+checksums="115d9122cc8ee91972ee07d8d706f246f53e7b9728574d7089683195d6194dee  aqua_darwin_arm64.tar.gz
 2e16e6685afb80534b7b985c5ba4b3786a7e42c5682bb44489bb5ab96558e208  aqua_windows_amd64.tar.gz
 2f4ff2ea2f8250c7bcd0c19bed7590714fb3d90e256dbc54eb23bda51fcf8c1d  aqua_linux_arm64.tar.gz
 56973b1e62535282f9fa73a0b07bf356317e0946d37270702d79b79598441e35  aqua_windows_arm64.tar.gz
 95f24bc92f16073bfab623ba56033d7df67a9073b441fa21c1efc347ffe293d7  aqua_linux_amd64.tar.gz
-bfe78ad630923c78fce0ccfe30c5c04b9188196351605d60e6f4710a31e9e2ea  aqua_darwin_amd64.tar.gz" | grep "$filename" | sha256sum -c
+bfe78ad630923c78fce0ccfe30c5c04b9188196351605d60e6f4710a31e9e2ea  aqua_darwin_amd64.tar.gz"
+
+echo "===> Verifying checksum of aqua $bootstrap_version ..." >&2
+if command -v sha256sum > /dev/null 2>&1; then
+  echo "$checksums" | grep "$filename" | sha256sum -c
+elif command -v shasum > /dev/null 2>&1; then
+  echo "$checksums" | grep "$filename" | shasum -a 256 -c
+else
+	echo "Skipped checksum verification of aqua $bootstrap_version, because both sha256sum and shasum aren't found" >&2
+fi
 
 tar xvzf "$filename" > /dev/null
 chmod a+x aqua


### PR DESCRIPTION
- Use `shasum` instead of `sha256sum` if `sha256sum` isn't found
- If `shasum` and `sha256sum` aren't found, the checksum verification is skipped