### PR TITLE
feat: pass github_token

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ inputs:
   aqua_version:
     description: Installed aqua's version (e.g. v0.8.7)
     required: true
+  github_token:
+    description: GitHub access token
+    required: false
+    default: ${{ github.token }}
   enable_aqua_install:
     required: false
     default: "true"
@@ -66,6 +70,7 @@ runs:
       env:
         AQUA_VERSION: ${{ inputs.aqua_version }}
         SKIP_INSTALL_AQUA: ${{ inputs.skip_install_aqua }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - run: aqua policy allow
       working-directory: ${{ inputs.working_directory }}
@@ -86,3 +91,4 @@ runs:
       shell: bash
       env:
         AQUA_OPTS: ${{ inputs.aqua_opts }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
## ⚠️ Breaking Changes

If you pass a GitHub Access token via environment variable `env`, it would be overridden by the input `github_token`.

```yaml
uses: aquaproj/aqua-installer@v2.0.0
env:
  GITHUB_TOKEN: ${{secrets.PAT}} # This is overridden by ${{github.token}}
```

### How to migrate

Pass a GitHub access token by the input `github_token`.

```yaml
uses: aquaproj/aqua-installer@v2.0.0
with:
  github_token: ${{secrets.PAT}}
```

### Why is this breaking change required?

Recently, GitHub updated rate limits for unauthenticated requests.

https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/

As a result, aqua-installer often hits the API rate limit if a GitHub access token isn't passed via environment variable.

e.g. https://github.com/szksh-lab/.github/actions/runs/15082243052/job/42400373723

```
time="2025-05-17T05:48:24Z" level=error msg="install the registry" aqua_version=2.51.2 env=linux/amd64 error="get a file by Get GitHub Content API: status code 429" program=aqua registry_name=standard
time="2025-05-17T05:48:24Z" level=fatal msg="aqua failed" aqua_version=2.51.2 env=linux/amd64 error="it failed to install some registries" program=aqua
```

It failed to download the standard registry by GitHub content API.

To resolve the issue, we pass a GitHub actions token by default.
And we add the input `github_token` to allow you to change the access token.

## Features

The input `github_token` is added.
You can pass a GitHub access token by input.
By default, GitHub Actions token `${{github.token}}` is passed.