### PR TITLE
chore: update the bootstrap version of aqua to v2.53.3

### DIFF
--- a/aqua-installer
+++ b/aqua-installer
@@ -51,13 +51,13 @@ done
 
 shift $((OPTIND - 1))
 
-bootstrap_version=v2.51.2
-checksums="ccca5f1c6473aa1fe67f84b244656290ac72e26998ef3479e00843b6b3e52650  aqua_darwin_amd64.tar.gz
-4ff9a263f6125369b391d37ad6593a8b987aae672c311f61859c4db986732357  aqua_darwin_arm64.tar.gz
-17db2da427bde293b1942e3220675ef796a67f1207daf89e6e80fea8d2bb8c22  aqua_linux_amd64.tar.gz
-b3f0d573e762ce9d104c671b8224506c4c4a32eedd1e6d7ae1e1e39983cdb6a8  aqua_linux_arm64.tar.gz
-bcac8677b632009ba9b561d38dddb0e07c55c5ac4690e0deb1a24b9e0cf282c8  aqua_windows_amd64.zip
-3d76eaaf9211aeb6186f1829ff21930a798a45163fac58c4ab5aa753a3220616  aqua_windows_arm64.zip"
+bootstrap_version=v2.53.3
+checksums="e4e20219789db4ade531a892a8b41e8604cfa21d03eef73cd4e5e0347bfb9755  aqua_darwin_amd64.tar.gz
+da9eccc80c63d336284560c141c1be8aca44b0d595f59a6ede5c7fe9281733a1  aqua_darwin_arm64.tar.gz
+2450bcf687c93e91ec892d49e5787b5b856796d38eb7283f52a351d82a8e31ee  aqua_linux_amd64.tar.gz
+562ad1f387f21161ab37eee24a3db99ed535488fe72bdc118866b854526494ca  aqua_linux_arm64.tar.gz
+c56a50182569f6733595af0114948bab8ef85db73e61c0abcc1a62c15b9e8b14  aqua_windows_amd64.zip
+a42d7b08e0841f064deb2b967a78ccdf00e18ab3e0840c496812adc539defed3  aqua_windows_arm64.zip"
 
 filename=aqua_${OS}_${ARCH}.tar.gz
 if [ "$OS" = windows ]; then


### PR DESCRIPTION
aqua v2.53.0 supported retring downloads.

https://github.com/aquaproj/aqua/releases/tag/v2.53.0