### PR TITLE
feat: add GitHub token authentication support

### DIFF
--- a/aqua-installer
+++ b/aqua-installer
@@ -68,10 +68,26 @@ URL=https://github.com/aquaproj/aqua/releases/download/$bootstrap_version/$filen
 tempdir=$(mktemp -d)
 echo "[INFO] Installing aqua $bootstrap_version for bootstrapping..." >&2
 echo "[INFO] Downloading $URL ..." >&2
+
+# Prepare authentication header if GITHUB_TOKEN is available
+auth_header=""
+if [ -n "$GITHUB_TOKEN" ]; then
+	echo "[INFO] Using GitHub authentication" >&2
+	auth_header="Authorization: Bearer $GITHUB_TOKEN"
+fi
+
 if command -v curl > /dev/null 2>&1; then
-	curl --retry 5 --fail -L "$URL" -o "$tempdir/$filename"
+	if [ -n "$auth_header" ]; then
+		curl --retry 5 --fail -L -H "$auth_header" "$URL" -o "$tempdir/$filename"
+	else
+		curl --retry 5 --fail -L "$URL" -o "$tempdir/$filename"
+	fi
 elif command -v wget > /dev/null 2>&1; then
-	wget -P "$tempdir" "$URL"
+	if [ -n "$auth_header" ]; then
+		wget --header="$auth_header" -P "$tempdir" "$URL"
+	else
+		wget -P "$tempdir" "$URL"
+	fi
 else
 	echo "[ERROR] Neither curl nor wget is found. Please install either curl or wget to download aqua" >&2
 	exit 1


### PR DESCRIPTION
## Summary

Adds optional GitHub token authentication support to the aqua-installer script, enabling authenticated downloads when the `GITHUB_TOKEN` environment variable is available. The action.yaml sets the GITHUB_TOKEN environment variable, so the aqua-installer action user can utilize their token to fetch the aqua binary.
This moves the request from IP-address-based GitHub rate limit budget to identity-based one, which has higher rate limits.

https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28

## Changes Made

- **Rate Limit Benefits**: Authenticated requests get higher GitHub API rate limits (1,000/hr vs 60/hr on the primary rate limit)
- **Conditional Authentication**: Uses `Authorization: Bearer` header when `GITHUB_TOKEN` is set
- **Backward Compatibility**: Maintains existing unauthenticated behavior when no token is provided

## Benefits

- **Higher Rate Limits**: Authenticated requests avoid GitHub's strict rate limiting
- **Future-Proof**: Aligns with GitHub's recommended authentication practices
- **Zero Breaking Changes**: Existing usage patterns continue to work unchanged

## Usage

```bash
# Existing usage (unchanged)
./aqua-installer

# New authenticated usage
GITHUB_TOKEN=ghp_xxxxxxxxxxxx ./aqua-installer
```

## Testing

- Tested with both `curl` and `wget`
- Verified backward compatibility with unauthenticated requests
- Confirmed proper header formatting for GitHub API authentication
