### PR TITLE
fix(aqua-installer): add --force flag

### DIFF
--- a/aqua-installer
+++ b/aqua-installer
@@ -118,4 +118,4 @@ echo ""
 
 "$install_path" -v
 
-rm -R "$tempdir"
+rm -Rf "$tempdir"


### PR DESCRIPTION
Add the `-f` flag to `rm` when deleting the temporary directory. Without the `-f` flag `rm` will prompt to delete read-only files in the `third_party_licenses` directory from aqua releases.